### PR TITLE
GPU selection added to online sounddevice example

### DIFF
--- a/examples/online_sounddevice.py
+++ b/examples/online_sounddevice.py
@@ -31,10 +31,12 @@ params = dict(
         chunksize=chunksize, backward_chunksize=backward_chunksize, 
     )
 
+gpu_platform_index = 0 # Put None to manually select
+gpu_device_index   = 1 # Put None to manually select
 
 processing = hls.InvComp(nb_channel=nb_channel, sample_rate=sample_rate,
         dtype='float32', apply_configuration_at_init=False, **params)
-processing.initialize()
+processing.initialize(gpu_platform_index, gpu_device_index)
 
 
 # define the callback audio wire

--- a/hearinglosssimulator/common.py
+++ b/hearinglosssimulator/common.py
@@ -185,14 +185,14 @@ class BaseMultiBand:
             self._save_filters()
         
     
-    def initialize(self):
+    def initialize(self, gpu_platform_index, gpu_device_index):
         if self.use_filter_cache and self._attr_to_save is not None:
             self._load_or_make_filters()
         else:
             self.make_filters()
         
         if self.ctx is None:
-            self.create_opencl_context()
+            self.create_opencl_context(gpu_platform_index=gpu_platform_index, gpu_device_index=gpu_device_index)
         
         self.initlalize_cl()
         


### PR DESCRIPTION
Hello, 
I needed to set the gpu device id in order to get the online sounddevice demo to run. I added the option that the user can specify the gpu device to the example, just as in your offline example.